### PR TITLE
工作：更新 POSH 版本比較和架構

### DIFF
--- a/SH/oh-my-posh-update.sh
+++ b/SH/oh-my-posh-update.sh
@@ -7,7 +7,7 @@ YELLOW='\033[0;33m' # 黄色
 NC='\033[0m'     # 重置颜色
 
 # 定義Oh My Posh 系統平台
-POSH=posh-linux-amd64 # posh-linux-arm64
+POSH=posh-linux-amd64
 
 # 定義版本比較函式
 version_compare() {


### PR DESCRIPTION
- 將 `POSH` 的值從 `posh-linux-arm64` 更改為 `posh-linux-amd64`
- 刪除被註解掉的行 `# posh-linux-arm64`
- 更新 `version_compare` 函數以移除版本號碼前面的 `v` 字元
