### PR TITLE
工作：更新 automerge-action 步驟並刪除不必要的欄位

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,4 +1,4 @@
-name: Automerge
+name: automerge
 
 on:
   pull_request:
@@ -20,14 +20,13 @@ on:
   status: {}
 
 jobs:
-  # 合併發布版本的 pr 到 main
-  auto-merge:
+  automerge:
     runs-on: ubuntu-latest
     steps:
-      - name: Automerge
-        uses: 'pascalgn/automerge-action@v0.15.6'
+      - id: automerge
+        name: automerge
+        uses: "pascalgn/automerge-action@v0.16.2"
         env:
-          GITHUB_TOKEN: '${{ secrets.RELEASE_TOKEN }}'
+          GITHUB_TOKEN: "${{ secrets.RELEASE_TOKEN }}"
           MERGE_LABELS: ''
-          # 只要是 cloverdefa 帳號，都進行自動合併
           MERGE_FILTER_AUTHOR: 'cloverdefa'


### PR DESCRIPTION
- 將「name」欄位從「Automerge」變更為「automerge」
- 將「automerge」步驟中的「uses」欄位從「pascalgn/automerge-action@v0.15.6」更新為「pascalgn/automerge-action@v0.16.2」
-將「GITHUB_TOKEN」的值從「'${{secrets.RELEASE_TOKEN}}'」更新為「"${{secrets.RELEASE_TOKEN}}"」
- 刪除「MERGE_LABELS」欄位
- 刪除有關「cloverdefa」帳戶的自動合併註解

Signed-off-by: Macbook <jackie@dast.tw>
