### PR TITLE
功能：新增 Bash 腳本以透過 SSH 重新啟動遠端裝置上的 PoE 操作

### DIFF
--- a/SH/poe-restart.sh
+++ b/SH/poe-restart.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# 遠程設備的SSH設定
+SSH_HOST="switch-core"  # 設定SSH主機名稱或IP地址
+SSH_USER="cloverdefa"  # 設定SSH用戶名
+SSH_KEY="~/.ssh/id_rsa"  # 私鑰文件的路徑
+
+# 設置命令
+CONFIG_COMMANDS=(
+    "telnet localhost"  # 進入telnet模式
+    "enable"  # 啟用特權模式
+    "configure"  # 進入配置模式
+    "interface 0/1"  # 進入0/1介面配置模式
+    "poe opmode shutdown"  # 設置PoE操作模式為關閉
+    "poe opmode auto"  # 再次設置PoE操作模式為自動
+    "exit"  # 退出介面配置模式
+    "exit"  # 退出配置模式
+    "exit"  # 退出特權模式
+    "exit"  # 退出telnet
+    "exit"  # 退出SSH會話
+)
+
+# 使用SSH金鑰認證連接和配置遠程設備
+ssh -i "$SSH_KEY" "$SSH_USER"@"$SSH_HOST" << EOF
+    for cmd in "\${CONFIG_COMMANDS[@]}"; do
+        echo "\$cmd"
+        sleep 1
+    done
+    exit
+EOF
+
+# 檢查SSH連接的退出狀態
+if [ $? -ne 0 ]; then
+    echo "無法建立SSH連接。"
+    exit 1
+fi


### PR DESCRIPTION
- 新增一個名為 `poe-restart.sh` 的 Bash 腳本檔案
- 該腳本透過 SSH 連接到遠端裝置並進行配置
- SSH 主機、使用者和私鑰路徑被設定為變數
- 腳本使用 telnet 命令來配置遠端裝置
- PoE 操作模式被設定為關閉，然後再恢復為自動模式
- 腳本結束 telnet、SSH 和腳本會話
- 檢查 SSH 連接狀態，如果連接失敗則顯示錯誤訊息並退出

Signed-off-by: DAST-HomePC <jackie@dast.tw>
