### PR TITLE
功能：添加用於檔案更名的新 Python 腳本

### DIFF
--- a/PS1/hath-rename.py
+++ b/PS1/hath-rename.py
@@ -1,0 +1,27 @@
+import os
+
+def rename_files(folder_path):
+    for root, dirs, files in os.walk(folder_path):
+        for file in files:
+            file_path = os.path.join(root, file)
+            filename, file_extension = os.path.splitext(file)
+
+            if '-jpg' in filename and not file_extension:
+                new_file_path = os.path.join(root, filename.replace('-jpg', '') + '.jpg')
+                os.rename(file_path, new_file_path)
+                print(f'Renamed: {file_path} to {new_file_path}')
+            
+            elif '-gif' in filename and not file_extension:
+                new_file_path = os.path.join(root, filename.replace('-gif', '') + '.gif')
+                os.rename(file_path, new_file_path)
+                print(f'Renamed: {file_path} to {new_file_path}')
+
+if __name__ == "__main__":
+    current_path = os.getcwd()
+    cache_path = os.path.join(current_path, 'cache')
+
+    if os.path.exists(cache_path):
+        rename_files(cache_path)
+        print("Task completed successfully.")
+    else:
+        print(f"The specified folder '{cache_path}' does not exist.")


### PR DESCRIPTION
- 添加一個新的 Python 檔案 `hath-rename.py`，其中包含一個用於更名檔案的函數
- 函數 `rename_files` 用於更名檔名包含 “-jpg” 或 “-gif” 但沒有擴展名的檔案
- 新增列印語句以顯示更名過程
- 在對包含 “-jpg” 或 “-gif” 擴展名的檔案進行更名之前，檢查緩存資料夾是否存在
