### PR TITLE
重構: 重構檔案處理和主機迭代

### DIFF
--- a/SH/check-inform.sh
+++ b/SH/check-inform.sh
@@ -1,38 +1,28 @@
 #!/usr/bin/env bash
 
-# 目標機器列表
-hosts=(
-    "uxg"
-    "switch-core"
-    "switch-weakcurrentbox"
-    "ap-livingroom"
-    "ap-workingroom"
-    "ap-bedroom"
-    "switch-office"
-    "weifan1-switch-1f"
-    "weifan1-switch-2f"
-    "weifan1-ap-1f"
-    "weifan1-ap-2f"
-    "weifan2-uxg"
-    "weifan2-switch-1f"
-    "weifan2-switch-2f"
-    "weifan2-ap-1f"
-    "weifan2-ap-2f"
-)
+# 檢查檔案是否存在
+if [ -f ~/.config/list/.unifi.list ]; then
+    # 讀取檔案內容並存儲到陣列中
+    mapfile -t hosts < ~/.config/list/.unifi.list
 
-# 遍歷目標機器列表
-for host in "${hosts[@]}"; do
-    echo "連接到 $host..."
-    # 連接到目標機器，並執行 mca-cli-op info 指令，將結果保存到變數 feedback 中
-    feedback=$(ssh "$host" 'mca-cli-op info')
-    # 顯示目標機器的回饋信息
-    echo "來自 $host 的回饋:"
-    echo "$feedback"
-    echo "---------------------------------------------"
-    
-    # 檢查回饋訊息是否包含 https://unifi:8080/inform，如果是，則提醒
-    if [[ "$feedback" =~ "https://unifi:8080/inform" ]]; then
-        echo "⚠️ 注意：連接機器 $host 需要重新設定連接 Unifi 控制器 inform"
+    # 遍歷目標機器清單
+    for host in "${hosts[@]}"; do
+        # 去除行尾的換行符
+        host=$(echo "$host" | tr -d '\n')
+        echo "連接到 $host..."
+        # 連接到目標機器，並執行 mca-cli-op info 指令，將結果保存到變數 feedback 中
+        feedback=$(ssh "$host" 'mca-cli-op info')
+        # 顯示目標機器的回饋信息
+        echo "來自 $host 的回饋:"
+        echo "$feedback"
         echo "---------------------------------------------"
-    fi
-done
+
+        # 檢查回饋訊息是否包含 https://unifi:8080/inform，如果是，則提醒
+        if [[ "$feedback" =~ "https://unifi:8080/inform" ]]; then
+            echo "⚠️ 注意：連接機器 $host 需要重新設定連接 Unifi 控制器 inform"
+            echo "---------------------------------------------"
+        fi
+    done
+else
+    echo "錯誤: 檔案 ~/.config/list/.unifi.list 不存在"
+fi


### PR DESCRIPTION
- 註釋掉先前的主機列表
- 重構為將檔案內容讀取並存儲到陣列
- 將迴圈描述更改為對目標主機列表進行迭代
- 修改以在連接之前從主機名稱中去除換行符
- 如果提及的檔案不存在，則添加錯誤訊息
