### PR TITLE
GIT 提交信息：

### DIFF
--- a/MacOS/git-pull-all-mac.sh
+++ b/MacOS/git-pull-all-mac.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env zsh
 
 # 定義顏色代碼
-RED='\033[0;31m' # 红色
-GREEN='\033[0;32m' # 绿色
-YELLOW='\033[0;33m' # 黄色 
-NC='\033[0m'     # 重置颜色
+RED='\033[0;31m'    # 红色
+GREEN='\033[0;32m'  # 绿色
+YELLOW='\033[0;33m' # 黄色
+NC='\033[0m'        # 重置颜色
 
 # 檢查 .repositories.list 檔案是否存在
 repositories_list="$HOME/.config/list/.repositories.list"
@@ -14,21 +14,21 @@ if [ ! -f "$repositories_list" ]; then
 fi
 
 # 從 .repositories.list 檔案中讀取伺服器名稱列表，並過濾掉空白以及注釋行
-repos=($(cat "$repositories_list" | grep -E -v '^\s*(#|$)'))
+repos=($(grep -E -v '^\s*(#|$)' "$repositories_list"))
 
 # 添加 dotfiles 儲存庫
 repos+=("dotfiles")
 
 # 使用函數來執行操作更新
-function Git-Pull-Repo() {
+function Git-Pull-Repo {
   local repo_name="$1"
   local repo_path="$HOME/Documents/github/$repo_name" # 使用$HOME環境變數
-  if [ "$repo_name" == "dotfiles" ]; then
+  if [ "$repo_name" = "dotfiles" ]; then
     repo_path="$HOME/$repo_name" # 對於dotfiles儲存庫，路徑是$HOME/dotfiles
   fi
   local text="$repo_name 拉取遠端資料"
 
-  cd "$repo_path" || exit 1 # 切換到存儲庫目錄如果切換失敗，退出，並返回結束碼1
+  cd "$repo_path" || { echo -e "${RED}錯誤：無法切換到目錄 $repo_path ${NC}"; exit 1; } # 切換到存儲庫目錄如果切換失敗，退出，並返回結束碼1
   echo -e "${GREEN}儲存庫名稱 $repo_name ${NC}"
 
   # 切換到主分支


### PR DESCRIPTION
重構：重構腳本以優化錯誤處理

- 更新腳本，直接在 `$repositories_list` 檔案上使用`grep` 以讀取伺服器名稱
- 在 repo_name 值的比較條件中將 `==` 替換為 `=`
- 新增錯誤訊息，以色彩編碼標示無法切換目錄的失敗情況

Signed-off-by: Macbook <jackie@dast.tw>
