### PR TITLE
build: update folder paths and printouts for syncing changes

### DIFF
--- a/Windows/git-pull-all.ps1
+++ b/Windows/git-pull-all.ps1
@@ -61,7 +61,7 @@ foreach ($repository in $repositories) {
 }
 
 <# 同步 nvim 資料夾到使用者目錄\AppData\Local\nvim #>
-$localNvimPath = "$env:USERPROFILE\AppData\Local\nvim"
+$localNvimPath = "$env:LOCALAPPDATA\Local\nvim"
 
 Write-Host "同步 nvim 資料夾到: $localNvimPath" -ForegroundColor Yellow
 


### PR DESCRIPTION
- Update the path for syncing the nvim folder to use `LOCALAPPDATA`.
- Adjust the path printout to reflect the updated folder location.

Signed-off-by: Macbook <jackie@dast.tw>
