### PR TITLE
fix: fix path separator in syncing files to user directory

### DIFF
--- a/Windows/git-pull-all.ps1
+++ b/Windows/git-pull-all.ps1
@@ -61,7 +61,7 @@ foreach ($repository in $repositories) {
 }
 
 <# 同步 nvim 資料夾到使用者目錄\AppData\Local\nvim #>
-$localNvimPath = "$env:LOCALAPPDATA\Local\nvim"
+$localNvimPath = "$env:LOCALAPPDATA\nvim"
 
 Write-Host "同步 nvim 資料夾到: $localNvimPath" -ForegroundColor Yellow
 


### PR DESCRIPTION
- Fix path separator in syncing `nvim` folder to user directory

Signed-off-by: HomePC <jackie@dast.tw>
