### PR TITLE
build: update server update commands and SSH scripts across OSs

### DIFF
--- a/Linux/update-vm.sh
+++ b/Linux/update-vm.sh
@@ -8,20 +8,20 @@ NC=$'\033[0m'        # 重置顏色
 
 # 建立函數用於執行 SSH 連接和執行更新命令
 function update_servers {
-	local server="$1"
-	echo -e "${YELLOW}連接到 $server${NC}"
+  local server="$1"
+  echo -e "${YELLOW}連接到 $server${NC}"
 
-	# 透過 SSH 連接至遠端伺服器，執行一系列指令
-	if ssh -n "$server" 'sudo apt-get update && sudo apt-get \
-    dist-upgrade -y && sudo apt-get autoremove -y \
-    && sudo apt-get autoclean -y'; then
-		echo -e "${GREEN}在 $server 上執行更新指令成功${NC}"
-	else
-		echo -e "${RED}無法執行更新因為 SSH 連接失敗${NC}"
-		update_error=1 # 標記更新錯誤
-	fi
-	# 顯示空行
-	echo ""
+  # 透過 SSH 連接至遠端伺服器，執行一系列指令
+  if ssh -n "$server" 'sudo nala update && sudo nala \
+    upgrade -y && sudo nala autoremove -y \
+    && sudo nala clean -y'; then
+    echo -e "${GREEN}在 $server 上執行更新指令成功${NC}"
+  else
+    echo -e "${RED}無法執行更新因為 SSH 連接失敗${NC}"
+    update_error=1 # 標記更新錯誤
+  fi
+  # 顯示空行
+  echo ""
 }
 
 # 讀取伺服器清單文件
@@ -29,8 +29,8 @@ server_list="$HOME/.config/list/.server.list"
 
 # 檢查清單列表文件是否存在
 if [ ! -f "$server_list" ]; then
-	echo -e "${RED}伺服器清單文件不存在: $server_list${NC}"
-	exit 1
+  echo -e "${RED}伺服器清單文件不存在: $server_list${NC}"
+  exit 1
 fi
 
 # 初始化錯誤標誌
@@ -38,14 +38,14 @@ update_error=0
 
 # 使用迴圈循環對伺服器清單內的每一台機器調用函數執行命令
 while IFS= read -r server; do
-	update_servers "$server"
+  update_servers "$server"
 done < <(grep -v '^\s*#' "$server_list" | grep -v '^\s*$')
 
 # 根據錯誤情況顯示不同的訊息
 if [ "$update_error" -eq 0 ]; then
-	echo -e "${GREEN}全部機器更新完成${NC}"
+  echo -e "${GREEN}全部機器更新完成${NC}"
 else
-	echo -e "${RED}更新過程發生錯誤${NC}"
+  echo -e "${RED}更新過程發生錯誤${NC}"
 fi
 
 # 結束程式

--- a/MacOS/update-vm-mac.sh
+++ b/MacOS/update-vm-mac.sh
@@ -12,8 +12,8 @@ function update_servers {
   echo -e "${YELLOW}連接到 $server${NC}"
 
   # 透過 SSH 連接至遠端伺服器，執行一系列指令
-  ssh "$server" 'sudo apt-get update && sudo apt-get dist-upgrade \
-    && sudo apt-get autoremove && sudo apt-get autoclean'
+  ssh "$server" 'sudo nala update && sudo nala upgrade \
+    && sudo nala autoremove && sudo nala clean'
 
   ssh_result=$?
 

--- a/Windows/update-vm.ps1
+++ b/Windows/update-vm.ps1
@@ -23,7 +23,7 @@ function Update-VM {
     Write-Host "更新 $hostname 伺服器" -ForegroundColor Yellow
 
     <# 使用 SSH 命令執行伺服器更新作業 #>
-    ssh $hostname 'sudo apt-get update && sudo apt-get dist-upgrade && sudo apt-get autoremove && sudo apt-get autoclean'
+    ssh $hostname 'sudo nala update && sudo nala upgrade && sudo nala autoremove && sudo nala clean'
 
     <# 檢查是否有更新錯誤，如果有，顯示錯誤訊息 #>
     if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
- Update the command sequence for server updating on Linux and MacOS
- Change the update command from `apt-get` to `nala` on Linux and MacOS
- Modify the SSH command to run server updates in the Windows script

Signed-off-by: HomePC-WSL <jackie@dast.tw>
