### PR TITLE
feat: update script for syncing `HOME/.fzf-git.sh` files

### DIFF
--- a/MacOS/mac-update.sh
+++ b/MacOS/mac-update.sh
@@ -33,3 +33,15 @@ fi
 if command -v zinit &>/dev/null; then
   zinit update
 fi
+
+# 同步 $HOME/.fzf-git.sh
+fzf_git_script="$HOME/.fzf-git.sh"
+fzf_git_dir="$HOME/.fzf-git.sh/.git"
+if [[ -d $fzf_git_script && -d $fzf_git_dir ]]; then
+  echo "==> Pulling latest changes for $fzf_git_script..."
+  (cd $fzf_git_script && git pull origin main)
+  echo "Updated $fzf_git_script."
+else
+  echo "$fzf_git_script is not a Git repository or does not exist. Skipping update."
+fi
+


### PR DESCRIPTION
- Update the `mac-update.sh` script to include syncing `HOME/.fzf-git.sh`
- Add a check to pull latest changes for `HOME/.fzf-git.sh` if it exists
- Display messages for updating or skipping the `fzf-git.sh` repository

Signed-off-by: Macbook <jackie@dast.tw>
