### PR TITLE
build: update package manager commands across scripts

### DIFF
--- a/Linux/update-vm.sh
+++ b/Linux/update-vm.sh
@@ -12,10 +12,10 @@ function update_servers {
   echo -e "${YELLOW}連接到 $server${NC}"
 
   # 透過 SSH 連接至遠端伺服器，執行一系列指令
-  if ssh -n "$server" 'sudo apt update \
-    && sudo apt dist-upgrade  -y && \
-    sudo apt autoremove -y \
-    && sudo apt autoclean'; then
+  if ssh -n "$server" 'sudo apt-get update \
+    && sudo apt-get dist-upgrade  -y && \
+    sudo apt-get autoremove -y \
+    && sudo apt-get autoclean'; then
     echo -e "${GREEN}在 $server 上執行更新指令成功${NC}"
   else
     echo -e "${RED}無法執行更新因為 SSH 連接失敗${NC}"

--- a/MacOS/update-vm-mac.sh
+++ b/MacOS/update-vm-mac.sh
@@ -12,10 +12,10 @@ function update_servers {
   echo -e "${YELLOW}連接到 $server${NC}"
 
   # 透過 SSH 連接至遠端伺服器，執行一系列指令
-  ssh "$server" 'sudo apt update && \
-    sudo apt dist-upgrade -y \
-    && sudo apt autoremove -y \
-    && sudo apt autoclean'
+  ssh "$server" 'sudo apt-get update && \
+    sudo apt-get dist-upgrade -y \
+    && sudo apt-get autoremove -y \
+    && sudo apt-get autoclean'
 
   ssh_result=$?
 

--- a/Windows/update-vm.ps1
+++ b/Windows/update-vm.ps1
@@ -23,7 +23,7 @@ function Update-VM {
     Write-Host "更新 $hostname 伺服器" -ForegroundColor Yellow
 
     <# 使用 SSH 命令執行伺服器更新作業 #>
-    ssh $hostname 'sudo apt update && sudo apt dist-upgrade -y && sudo apt autoremove -y && sudo apt autoclean'
+    ssh $hostname 'sudo apt-get update && sudo apt-get dist-upgrade -y && sudo apt-get autoremove -y && sudo apt-get autoclean'
 
     <# 檢查是否有更新錯誤，如果有，顯示錯誤訊息 #>
     if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
- Update the package manager commands from `apt` to `apt-get` for Linux and MacOS scripts
- Change the SSH command to update packages for the Windows script

Signed-off-by: OfficePC-WSL <jackie@dast.tw>
