### PR TITLE
refactor: refactor paths to utilize environment variables

### DIFF
--- a/Windows/update.ps1
+++ b/Windows/update.ps1
@@ -1,5 +1,5 @@
 # 更新 git repo
-# 檢查系統內是否安裝 git 並且在路徑 $HOME\github\Script\Windows 下是否有 git-pull-all.ps1 這個腳本
+# 檢查系統內是否安裝 git 並且在路徑 $env:USERPROFILE\github\Script\Windows 下是否有 git-pull-all.ps1 這個腳本
 if (Get-Command git -ErrorAction SilentlyContinue) {
     if (Test-Path "$env:USERPROFILE\github\Script\Windows\git-pull-all.ps1") {
         . "$env:USERPROFILE\github\Script\Windows\git-pull-all.ps1"
@@ -11,13 +11,13 @@ if (Get-Command git -ErrorAction SilentlyContinue) {
 }
 
 # 使用 winget 更新所有已安裝的應用程式
-winget update --all
+winget upgrade --all
 
 # 更新 Windows Subsystem for Linux (WSL) 到最新版本
 wsl --update
 
 # 檢查是否安裝 pip 在指定的路徑
-$pipPath = Join-Path "$env:USERPROFILE\AppData\Local\Programs\Python\Python312\Scripts\pip.exe"
+$pipPath = "$env:USERPROFILE\AppData\Local\Programs\Python\Python312\Scripts\pip.exe"
 if (Test-Path $pipPath) {
     & $pipPath install --upgrade debugpy hererocks pip pynvim
 } else {
@@ -25,7 +25,7 @@ if (Test-Path $pipPath) {
 }
 
 # 檢查更新 CodeGPT
-# 檢查是否有安裝 codegpt 並且在路徑 $HOME\github\Script\Windows 下是否有 codegpt-update.ps1 這個腳本
+# 檢查是否有安裝 codegpt 並且在路徑 $env:USERPROFILE\github\Script\Windows 下是否有 codegpt-update.ps1 這個腳本
 if (Get-Command codegpt -ErrorAction SilentlyContinue) {
     if (Test-Path "$env:USERPROFILE\github\Script\Windows\codegpt-update.ps1") {
         . "$env:USERPROFILE\github\Script\Windows\codegpt-update.ps1"
@@ -37,7 +37,7 @@ if (Get-Command codegpt -ErrorAction SilentlyContinue) {
 }
 
 # 檢查更新 yt-dlp
-# 檢查是否有安裝 yt-dlp 並且在路徑 $HOME\github\Script\Windows 下是否有 yt-dlp-update.ps1 這個腳本
+# 檢查是否有安裝 yt-dlp 並且在路徑 $env:USERPROFILE\github\Script\Windows 下是否有 yt-dlp-update.ps1 這個腳本
 if (Get-Command yt-dlp -ErrorAction SilentlyContinue) {
     if (Test-Path "$env:USERPROFILE\github\Script\Windows\yt-dlp-update.ps1") {
         . "$env:USERPROFILE\github\Script\Windows\yt-dlp-update.ps1"
@@ -54,3 +54,4 @@ if (Get-Command nvim -ErrorAction SilentlyContinue) {
 } else {
     Write-Host "Neovim 未安裝"
 }
+


### PR DESCRIPTION
- Update the path variable to use `env:USERPROFILE` instead of explicit path
- Change `winget update --all` to `winget upgrade --all`
- Use environment variable `env:USERPROFILE` in various path locations

Signed-off-by: HomePC <jackie@dast.tw>
