### PR TITLE
chore: upgrade package versions and improve error messages

### DIFF
--- a/Windows/update.ps1
+++ b/Windows/update.ps1
@@ -19,7 +19,7 @@ wsl --update
 # 檢查是否安裝 pip 在指定的路徑
 $pipPath = "$env:USERPROFILE\AppData\Local\Programs\Python\Python312\Scripts\pip.exe"
 if (Test-Path $pipPath) {
-    & $pipPath install --upgrade debugpy hererocks pip pynvim
+    & $pipPath install --upgrade debugpy hererocks pip pynvim pyinstaller
 } else {
     Write-Host "pip 未安裝或 pip 路徑不正確"
 }


### PR DESCRIPTION
- Add `pyinstaller` to the list of packages being upgraded
- Update the error message for when `pip` is not installed or path is incorrect

Signed-off-by: OfficePC <jackie@dast.tw>
