### PR TITLE
fix: update platform update scripts to use Lazy! update strategy

### DIFF
--- a/Linux/WSL-update.sh
+++ b/Linux/WSL-update.sh
@@ -89,6 +89,6 @@ fi
 # 更新 NVIM Lazy
 nvim="/opt/nvim-linux64/bin/nvim"
 if [ -f $nvim ]; then
-  nvim --headless "+Lazy! sync" +qa
-  sudo $nvim --headless "+Lazy! sync" +qa
+  nvim --headless "+Lazy! update" +qa
+  sudo $nvim --headless "+Lazy! update" +qa
 fi

--- a/MacOS/mac-update.sh
+++ b/MacOS/mac-update.sh
@@ -54,7 +54,7 @@ fi
 
 # Nvim Lazy Update
 if command -v nvim &>/dev/null; then
-  nvim --headless "+Lazy! sync" +qa
+  nvim --headless "+Lazy! update" +qa
 else
   echo "Nvim未安裝或正確設定,因此略過更新"
 fi

--- a/Windows/update.ps1
+++ b/Windows/update.ps1
@@ -59,7 +59,7 @@ if (Get-Command yt-dlp -ErrorAction SilentlyContinue) {
 
 # 檢查是否安裝 nvim，並在條件滿足時執行插件同步
 if (Get-Command nvim -ErrorAction SilentlyContinue) {
-    nvim --headless "+Lazy! sync" +qa
+    nvim --headless "+Lazy! update" +qa
 } else {
     Write-Host "Neovim 未安裝"
 }


### PR DESCRIPTION
- Update `Linux/WSL-update.sh` to use `Lazy! update` instead of `Lazy! sync`
- Update `MacOS/mac-update.sh` to use `Lazy! update` instead of `Lazy! sync`
- Update `Windows/update.ps1` to use `Lazy! update` instead of `Lazy! sync`

Signed-off-by: OfficePC-WSL <jackie@dast.tw>
