### PR TITLE
chore: update GitHub workflow configurations and dependencies

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -25,8 +25,8 @@ jobs:
     steps:
       - id: automerge
         name: automerge
-        uses: "pascalgn/automerge-action@v0.16.3"
+        uses: "pascalgn/automerge-action@v0.16.4"
         env:
           GITHUB_TOKEN: "${{ secrets.RELEASE_TOKEN }}"
-          MERGE_LABELS: ''
-          MERGE_FILTER_AUTHOR: 'cloverdefa'
+          MERGE_LABELS: ""
+          MERGE_FILTER_AUTHOR: "cloverdefa"


### PR DESCRIPTION
- Update the version of the `pascalgn/automerge-action` to `v0.16.4`
- Modify the `MERGE_LABELS` and `MERGE_FILTER_AUTHOR` values in the workflow configuration

Signed-off-by: OfficePC-WSL <jackie@dast.tw>
