### PR TITLE
build: refactor Python installation commands

### DIFF
--- a/Windows/update.ps1
+++ b/Windows/update.ps1
@@ -22,7 +22,7 @@ wsl --update
 # 檢查是否安裝 pip 在指定的路徑
 $pipPath = "$env:USERPROFILE\AppData\Local\Programs\Python\Python312\Scripts\pip.exe"
 if (Test-Path $pipPath) {
-    & $pipPath install --upgrade debugpy hererocks pip pynvim pyinstaller setuptools
+    & $pipPath install --upgrade debugpy hererocks pip pynvim setuptools
 } else {
     Write-Host "pip 未安裝或 pip 路徑不正確"
 }


### PR DESCRIPTION
- Update the pip installation command to exclude `pyinstaller`
- Correct the path for the Python installation directory

Signed-off-by: HomePC <jackie@dast.tw>
