### PR TITLE
feat: update public IP retrieval using Cloudflare DNS

### DIFF
--- a/Linux/get-public-ip.sh
+++ b/Linux/get-public-ip.sh
@@ -2,5 +2,5 @@
 
 if [[ -x "$(command -v dig)" ]]; then
   echo "Public IP Now Is"
-  dig TXT +short o-o.myaddr.l.google.com @ns1.google.com
+  dig +short txt ch whoami.cloudflare @1.0.0.1
 fi

--- a/MacOS/get-public-ip.sh
+++ b/MacOS/get-public-ip.sh
@@ -2,5 +2,5 @@
 
 if [[ -x "$(command -v dig)" ]]; then
   echo "Public IP Now Is"
-  dig TXT +short o-o.myaddr.l.google.com @ns1.google.com
+  dig +short txt ch whoami.cloudflare @1.0.0.1
 fi


### PR DESCRIPTION
- Update the DNS query to get the public IP address using Cloudflare instead of Google
- Modify the `get-public-ip.sh` script for both Linux and MacOS to reflect the new DNS query

Signed-off-by: Macbook <jackie@dast.tw>
